### PR TITLE
feat(next-app): Disable powered-by header

### DIFF
--- a/next-app/next.config.js
+++ b/next-app/next.config.js
@@ -1,5 +1,6 @@
 module.exports = {
 	distDir: 'dist',
+	poweredByHeader: false,
 	future: {
 		webpack5: true,
 	},


### PR DESCRIPTION
This is considered more secure as an attacker gets
fewer data points on the potential target.